### PR TITLE
Add environment pipelines

### DIFF
--- a/.github/actions/environment-action/action.yml
+++ b/.github/actions/environment-action/action.yml
@@ -1,0 +1,17 @@
+name: 'Environment Action'
+description: 'An action to set up the environment and consume secrets'
+inputs:
+  environment:
+    description: 'The chosen environment'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up environment
+      run: echo "Setting up environment"
+
+    - name: Consume secret
+      run: echo "Consuming secret: ${{ secrets.ENV_SECRET }}"
+
+    - name: Output environment
+      run: echo "## Chosen Environment: ${{ inputs.environment }}" > output.md

--- a/.github/workflows/environment-pipeline.yml
+++ b/.github/workflows/environment-pipeline.yml
@@ -1,20 +1,14 @@
-# Test
-
-## Environment Pipeline
-
-This repository contains a pipeline that consumes secrets from different environments and outputs the chosen environment via markdown.
-
-### Pipeline Configuration
-
-The pipeline is defined in the `.github/workflows/environment-pipeline.yml` file. Below is an example of the pipeline configuration:
-
-```yaml
 name: Environment Pipeline
 
 on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+      - develop
+      - test
 
 jobs:
   environment-pipeline:
@@ -35,4 +29,6 @@ jobs:
 
       - name: Output environment
         run: echo "## Chosen Environment: ${{ github.event.inputs.environment }}" > output.md
-```
+
+      - name: Echo environment variable
+        run: echo "Environment variable: $ENV_SECRET"


### PR DESCRIPTION
Related to #1

Add a pipeline to consume secrets from different environments and output the chosen environment via markdown.

* **README.md**
  - Add a section describing the new pipeline and how it consumes secrets from different environments.
  - Include an example of the pipeline configuration.

* **.github/workflows/environment-pipeline.yml**
  - Define a new GitHub Actions workflow for the pipeline.
  - Include steps to set up the environment and consume secrets.
  - Add a step to output the chosen environment via markdown.
  - Add a condition to run the pipeline on pull requests to `main`, `develop`, and `test` branches.
  - Add a separate action to echo out the environment variable.

* **.github/actions/environment-action/action.yml**
  - Define a new GitHub Actions action configuration file.
  - Include steps to set up the environment and consume secrets.
  - Add a step to output the chosen environment via markdown.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/schroedermarius/Test/issues/1?shareId=a4dd828b-eb19-4bd5-a329-6d51ea9d1b0c).